### PR TITLE
Add aarch64-linux binfmt emulation

### DIFF
--- a/modules/system/common.nix
+++ b/modules/system/common.nix
@@ -71,6 +71,9 @@
     # };
   };
 
+  # Enable aarch64 emulation (for cross-building RPi images etc.)
+  boot.binfmt.emulatedSystems = ["aarch64-linux"];
+
   boot.binfmt.registrations.appimage = {
     wrapInterpreterInShell = false;
     interpreter = "${pkgs.appimage-run}/bin/appimage-run";


### PR DESCRIPTION
Enables building aarch64-linux (Raspberry Pi) NixOS images from your x86_64 system via QEMU binfmt.

After rebuilding, `rpi5-build-sd-image` / `rpi5-flash-sd` will work natively.