### PR TITLE
networking: ignore DHCP DNS and set 1.1.1.1

### DIFF
--- a/modules/system/common.nix
+++ b/modules/system/common.nix
@@ -21,7 +21,18 @@
     flake = "/home/eran/dotfiles";
   };
 
-  networking.networkmanager.enable = true;
+  networking = {
+    networkmanager = {
+      enable = true;
+      dns = "none";
+    };
+
+    # Ignore DNS provided by DHCP and use static resolver.
+    dhcpcd.extraConfig = ''
+      nohook resolv.conf
+    '';
+    nameservers = ["1.1.1.1"];
+  };
   nix.settings = {
     experimental-features = ["nix-command" "flakes"];
     substituters = [


### PR DESCRIPTION
Summary:
- disable DNS from DHCP/NetworkManager handoff by setting networking.networkmanager.dns = "none"
- ignore dhcpcd DNS updates via dhcpcd nohook resolv.conf
- set static resolver networking.nameservers = [ "1.1.1.1" ]

Verification:
- Checked file diff in modules/system/common.nix and confirmed all three settings are present.

Note:
- Opened from node-openclaw/dotfiles branch fix/static-dns-no-dhcp-dns because this account cannot push directly to upstream.